### PR TITLE
Refactor/agent connection handling

### DIFF
--- a/internal/grpc/connection.go
+++ b/internal/grpc/connection.go
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with GoSight. If not, see https://www.gnu.org/licenses/.
 */
+
 // agent/internal/grpc/connection.go
 // Package grpcconn provides a singleton gRPC connection for the GoSight agent.
 package grpcconn
@@ -29,6 +30,7 @@ import (
 	"github.com/aaronlmathis/gosight-agent/internal/config"
 	agentutils "github.com/aaronlmathis/gosight-agent/internal/utils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
@@ -37,6 +39,14 @@ import (
 var (
 	conn   *grpc.ClientConn
 	connMu sync.Mutex
+)
+
+var (
+    pauseMu      sync.Mutex
+    pauseUntil   time.Time
+
+    disconnectMu sync.Mutex
+    disconnectCh = make(chan struct{})
 )
 
 // GetGRPCConn returns the singleton ClientConn for the gRPC connection.
@@ -48,11 +58,16 @@ func GetGRPCConn(cfg *config.Config) (*grpc.ClientConn, error) {
 	connMu.Lock()
 	defer connMu.Unlock()
 
-	if conn != nil {
-		// Optionally, add a check here to see if the existing connection is still healthy
-		// using conn.GetState() or a simple RPC call.
-		return conn, nil
-	}
+    // If we have one already, check its health.
+    if conn != nil {
+        state := conn.GetState()
+        if state == connectivity.Ready || state == connectivity.Idle {
+            return conn, nil
+        }
+        // Otherwise it's broken; close and reset.
+        _ = conn.Close()
+        conn = nil
+    }
 
 	tlsCfg, err := agentutils.LoadTLSConfig(cfg)
 	if err != nil {
@@ -96,4 +111,54 @@ func CloseGRPCConn() error {
 		return err
 	}
 	return nil
+}
+
+func GetPauseUntil() time.Time {
+    pauseMu.Lock()
+    pu := pauseUntil
+    pauseMu.Unlock()
+    return pu
+}
+
+// PauseConnections schedules a global pause of duration d,
+// and broadcasts one “disconnect” event on disconnectCh.
+func PauseConnections(d time.Duration) {
+    // set the pause deadline
+    pauseMu.Lock()
+    pauseUntil = time.Now().Add(d)
+    pauseMu.Unlock()
+
+	// Immediately tear down the shared gRPC connection
+	_ = CloseGRPCConn()
+
+	disconnectMu.Lock()
+    // non-blocking broadcast into the buffered channel
+    select {
+    case disconnectCh <- struct{}{}:
+    default:
+        // if the buffer is full, we’ve already signaled — no need to block
+    }
+	disconnectMu.Unlock()
+}
+// WaitForResume blocks until time.Now() ≥ pauseUntil.
+// Even if pauseUntil was extended mid-sleep, this will re-check.
+func WaitForResume() {
+    for {
+        pauseMu.Lock()
+        pu := pauseUntil
+        pauseMu.Unlock()
+
+        now := time.Now()
+        if now.Before(pu) {
+            time.Sleep(pu.Sub(now))
+            continue
+        }
+        return
+    }
+}
+
+// DisconnectNotify returns the channel that will get
+// one event each time PauseConnections is called.
+func DisconnectNotify() <-chan struct{} {
+    return disconnectCh
 }

--- a/internal/logs/logcollector/doc.go
+++ b/internal/logs/logcollector/doc.go
@@ -1,3 +1,3 @@
 // internal/logs/logcollector/doc.go
-// Package logcollector contains log collection infrastructure including runners, collectors, and senders.
+// Package logcollector contains log collection
 package logcollector

--- a/internal/logs/logsender/sender.go
+++ b/internal/logs/logsender/sender.go
@@ -20,162 +20,156 @@ import (
 
 // LogSender holds the gRPC client, connection, and stream.
 type LogSender struct {
-    client proto.LogServiceClient
-    cc     *grpc.ClientConn
-    stream proto.LogService_SubmitStreamClient
-    wg     sync.WaitGroup
-    cfg    *config.Config
-    ctx    context.Context
+	client proto.LogServiceClient
+	cc     *grpc.ClientConn
+	stream proto.LogService_SubmitStreamClient
+	wg     sync.WaitGroup
+	cfg    *config.Config
+	ctx    context.Context
 }
 
-// NewSender returns immediately and launches the background connection manager.
+// NewSender initializes a new LogSender and starts the connection manager.
+// It returns immediately and launches the background connection manager.
 func NewSender(ctx context.Context, cfg *config.Config) (*LogSender, error) {
-    s := &LogSender{ctx: ctx, cfg: cfg}
-    go s.manageConnection()
-    return s, nil
+	s := &LogSender{ctx: ctx, cfg: cfg}
+	go s.manageConnection()
+	return s, nil
 }
 
 // manageConnection dials & opens the SubmitStream, tears it down on global disconnect,
 // and retries with exponential backoff up to totalCap, then fixed-interval.
 // in logsender/sender.go
 func (s *LogSender) manageConnection() {
-    const (
-        initial    = 1 * time.Second
-        maxBackoff = 10 * time.Second
-        totalCap   = 15 * time.Minute
-    )
+	const (
+		initial    = 1 * time.Second
+		maxBackoff = 10 * time.Second
+		totalCap   = 15 * time.Minute
+	)
 
-    backoff := initial
-    elapsed := time.Duration(0)
-    var lastPause time.Time
+	backoff := initial
+	elapsed := time.Duration(0)
+	var lastPause time.Time
 
-    for {
-        // 1) If a new global pause began, tear down stream AND conn
-        pu := grpcconn.GetPauseUntil()
-        if pu.After(lastPause) {
-            utils.Info("Global disconnect: closing log stream and connection")
-            if s.stream != nil {
-                _ = s.stream.CloseSend()
-            }
-            // clear both so we re-dial completely
-            s.stream = nil
-            s.cc = nil
-            backoff = initial
-            elapsed = 0
-            lastPause = pu
-        }
+	for {
+		// If we've just been told to pause (disconnect), tear down both stream & conn once
+		pu := grpcconn.GetPauseUntil()
+		if pu.After(lastPause) {
+			utils.Info("Global disconnect: closing log stream and connection")
+			if s.stream != nil {
+				_ = s.stream.CloseSend()
+			}
 
-        // 2) Sleep out the pause window
-        grpcconn.WaitForResume()
+			s.stream = nil
+			backoff = initial
+			elapsed = 0
+			lastPause = pu
+		}
 
-        // 3) Dial (or re-use) a healthy ClientConn
-        if s.cc == nil {
-            cc, err := grpcconn.GetGRPCConn(s.cfg)
-            if err != nil {
-                utils.Info("Server offline (dial): retrying in %s", backoff)
-                time.Sleep(backoff)
-                elapsed += backoff
-                if backoff < maxBackoff {
-                    backoff *= 2
-                }
-                if elapsed >= totalCap {
-                    backoff = totalCap
-                }
-                continue
-            }
-            s.cc = cc
-            s.client = proto.NewLogServiceClient(cc)
-            // reset backoff on successful dial
-            backoff = initial
-            elapsed = 0
-        }
+		// Wait out the pause window (returns when pauseUntil ≤ now)
+		grpcconn.WaitForResume()
 
-        // 4) Open the SubmitStream if we don’t already have one
-        if s.stream == nil {
-            st, err := s.client.SubmitStream(s.ctx)
-            if err != nil {
-                utils.Info("Server offline (stream): retrying in %s", backoff)
-                time.Sleep(backoff)
-                elapsed += backoff
-                if backoff < maxBackoff {
-                    backoff *= 2
-                }
-                if elapsed >= totalCap {
-                    backoff = totalCap
-                }
-                continue
-            }
-            s.stream = st
-            utils.Info("Log stream connected")
-            // reset backoff on successful stream open
-            backoff = initial
-            elapsed = 0
-        }
+		cc, err := grpcconn.GetGRPCConn(s.cfg)
+		if err != nil {
+			utils.Info("Server offline (dial): retrying in %s", backoff)
+			time.Sleep(backoff)
+			elapsed += backoff
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			if elapsed >= totalCap {
+				backoff = totalCap
+			}
+			continue
+		}
+		s.cc = cc
+		s.client = proto.NewLogServiceClient(cc)
 
-        // 5) Brief pause before looping to catch disconnects
-        time.Sleep(time.Second)
-    }
+		// Open the SubmitStream if we don’t already have one
+		if s.stream == nil {
+			st, err := s.client.SubmitStream(s.ctx)
+			if err != nil {
+				utils.Info("Server offline (stream): retrying in %s", backoff)
+				time.Sleep(backoff)
+				elapsed += backoff
+				if backoff < maxBackoff {
+					backoff *= 2
+				}
+				if elapsed >= totalCap {
+					backoff = totalCap
+				}
+				continue
+			}
+			s.stream = st
+			utils.Info("Log stream connected")
+			// reset on successful stream open
+			backoff = initial
+			elapsed = 0
+		}
+
+		// 5) Brief pause to catch any new disconnects
+		time.Sleep(time.Second)
+	}
 }
-
 
 // SendLogs marshals the LogPayload and sends it.
 // If no active stream, returns Unavailable so your worker backoff kicks in.
 func (s *LogSender) SendLogs(payload *model.LogPayload) error {
-    if s.stream == nil {
-        return status.Error(codes.Unavailable, "no active log stream")
-    }
-    // --- begin conversion ---
-    // Convert LogPayload to proto.LogPayload
-    pbLogs := make([]*proto.LogEntry, 0, len(payload.Logs))
-    for _, log := range payload.Logs {
-        pb := &proto.LogEntry{
-            Timestamp: timestamppb.New(log.Timestamp),
-            Level:     log.Level,
-            Message:   log.Message,
-            Source:    log.Source,
-            Category:  log.Category,
-            Pid:       int32(log.PID),
-            Fields:    log.Fields,
-            Tags:      log.Tags,
-            Meta:      protohelper.ConvertLogMetaToProto(log.Meta),
-        }
-        pbLogs = append(pbLogs, pb)
-    }
-    var metaProto *proto.Meta
-    if payload.Meta != nil {
-        metaProto = protohelper.ConvertMetaToProtoMeta(payload.Meta)
-    }
-    req := &proto.LogPayload{
-        AgentId:    payload.AgentID,
-        HostId:     payload.HostID,
-        Hostname:   payload.Hostname,
-        EndpointId: payload.EndpointID,
-        Timestamp:  timestamppb.New(payload.Timestamp),
-        Logs:       pbLogs,
-        Meta:       metaProto,
-    }
-    // --- end conversion ---
+	if s.stream == nil {
+		return status.Error(codes.Unavailable, "no active log stream")
+	}
+	// --- begin conversion ---
+	// Convert LogPayload to proto.LogPayload
+	pbLogs := make([]*proto.LogEntry, 0, len(payload.Logs))
+	for _, log := range payload.Logs {
+		pb := &proto.LogEntry{
+			Timestamp: timestamppb.New(log.Timestamp),
+			Level:     log.Level,
+			Message:   log.Message,
+			Source:    log.Source,
+			Category:  log.Category,
+			Pid:       int32(log.PID),
+			Fields:    log.Fields,
+			Tags:      log.Tags,
+			Meta:      protohelper.ConvertLogMetaToProto(log.Meta),
+		}
+		pbLogs = append(pbLogs, pb)
+	}
+	var metaProto *proto.Meta
+	if payload.Meta != nil {
+		metaProto = protohelper.ConvertMetaToProtoMeta(payload.Meta)
+	}
+	req := &proto.LogPayload{
+		AgentId:    payload.AgentID,
+		HostId:     payload.HostID,
+		Hostname:   payload.Hostname,
+		EndpointId: payload.EndpointID,
+		Timestamp:  timestamppb.New(payload.Timestamp),
+		Logs:       pbLogs,
+		Meta:       metaProto,
+	}
+	// --- end conversion ---
 
-    // verify marshal
-    if _, err := goproto.Marshal(req); err != nil {
-        utils.Error("Failed to marshal LogPayload: %v", err)
-        return err
-    }
+	// verify marshal
+	if _, err := goproto.Marshal(req); err != nil {
+		utils.Error("Failed to marshal LogPayload: %v", err)
+		return err
+	}
 
-    // send
-    utils.Info("Sending %d logs to server", len(pbLogs))
-    if err := s.stream.Send(req); err != nil {
-        utils.Warn("Log stream send failed: %v", err)
-        return err
-    }
-    utils.Debug("Streamed %d logs", len(pbLogs))
-    return nil
+	// send
+	utils.Info("Sending %d logs to server", len(pbLogs))
+	if err := s.stream.Send(req); err != nil {
+		utils.Warn("Log stream send failed: %v", err)
+		return err
+	}
+	utils.Debug("Streamed %d logs", len(pbLogs))
+	return nil
 }
 
 // Close shuts down worker pool and closes the gRPC connection.
 func (s *LogSender) Close() error {
-    utils.Info("Closing LogSender... waiting for workers")
-    s.wg.Wait()
-    utils.Info("All LogSender workers finished")
-    return s.cc.Close()
+	utils.Info("Closing LogSender... waiting for workers")
+	s.wg.Wait()
+	utils.Info("All LogSender workers finished")
+	return s.cc.Close()
 }

--- a/internal/logs/logsender/sender.go
+++ b/internal/logs/logsender/sender.go
@@ -1,30 +1,9 @@
-/*
-SPDX-License-Identifier: GPL-3.0-or-later
-
-Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
-
-This file is part of GoSight.
-
-GoSight is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-GoSight is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with GoSight. If not, see https://www.gnu.org/licenses/.
-*/
-
 package logsender
 
 import (
 	"context"
-	"fmt"
 	"sync"
+	"time"
 
 	"github.com/aaronlmathis/gosight-agent/internal/config"
 	grpcconn "github.com/aaronlmathis/gosight-agent/internal/grpc"
@@ -39,151 +18,154 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Sender holds the gRPC client and connection
+// LogSender holds the gRPC client, connection, and stream.
 type LogSender struct {
-	client proto.LogServiceClient
-	cc     *grpc.ClientConn
-	stream proto.LogService_SubmitStreamClient
-	wg     sync.WaitGroup
-	Config *config.Config
+    client proto.LogServiceClient
+    cc     *grpc.ClientConn
+    stream proto.LogService_SubmitStreamClient
+    wg     sync.WaitGroup
+    cfg    *config.Config
+    ctx    context.Context
 }
 
-// NewSender establishes a gRPC connection to the server and creates a new LogSender instance.
-// It takes a context and a configuration object as parameters.
-// The function returns a pointer to the LogSender instance and an error if any occurs during the process.
-// It also sets up a stream for sending log data to the server.
+// NewSender returns immediately and launches the background connection manager.
 func NewSender(ctx context.Context, cfg *config.Config) (*LogSender, error) {
-	clientConn, err := grpcconn.GetGRPCConn(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	client := proto.NewLogServiceClient(clientConn)
-	utils.Info("established gRPC Connection with %v", cfg.Agent.ServerURL)
-
-	//
-	stream, err := client.SubmitStream(ctx)
-	if err != nil {
-		utils.Debug("Failed to open stream: %v", err)
-		return nil, fmt.Errorf("failed to open stream: %w", err)
-	}
-
-	return &LogSender{
-		client: client,
-		cc:     clientConn,
-		stream: stream,
-		Config: cfg,
-	}, nil
-
+    s := &LogSender{ctx: ctx, cfg: cfg}
+    go s.manageConnection()
+    return s, nil
 }
 
-// Close closes the gRPC connection and waits for all workers to finish.
-// It returns an error if any occurs during the process.
-// The function uses a wait group to ensure that all workers have completed their tasks
-// before closing the connection. It also logs the status of the workers.
-func (s *LogSender) Close() error {
-	utils.Info("Closing LogSender... waiting for workers")
-	s.wg.Wait()
-	utils.Info("All LogSender workers finished")
-	return s.cc.Close()
+// manageConnection dials & opens the SubmitStream, tears it down on global disconnect,
+// and retries with exponential backoff up to totalCap, then fixed-interval.
+func (s *LogSender) manageConnection() {
+    const (
+        initial    = 1 * time.Second
+        maxBackoff = 10 * time.Second
+        totalCap   = 15 * time.Minute
+    )
+
+    backoff := initial
+    elapsed := time.Duration(0)
+    var lastPause time.Time
+
+    for {
+        // 1) If a new global pause was issued, tear down our stream once
+        pu := grpcconn.GetPauseUntil()
+        if pu.After(lastPause) {
+            utils.Info("Global disconnect: closing log stream")
+            if s.stream != nil {
+                _ = s.stream.CloseSend()
+            }
+            s.stream = nil
+            backoff = initial
+            elapsed = 0
+            lastPause = pu
+        }
+
+        // Wait out any pause window
+        grpcconn.WaitForResume()
+
+        // Dial (or reuse) a healthy ClientConn
+        cc, err := grpcconn.GetGRPCConn(s.cfg)
+        if err != nil {
+            utils.Warn("gRPC dial failed for logs: %v", err)
+            time.Sleep(backoff)
+            elapsed += backoff
+            if backoff < maxBackoff {
+                backoff *= 2
+            }
+            if elapsed >= totalCap {
+                backoff = totalCap
+            }
+            continue
+        }
+        s.cc = cc
+        s.client = proto.NewLogServiceClient(cc)
+        backoff = initial
+        elapsed = 0
+
+        // Open the SubmitStream if we don’t already have one
+        if s.stream == nil {
+            st, err := s.client.SubmitStream(s.ctx)
+            if err != nil {
+                utils.Warn("Log stream open failed: %v", err)
+                time.Sleep(backoff)
+                elapsed += backoff
+                if backoff < maxBackoff {
+                    backoff *= 2
+                }
+                if elapsed >= totalCap {
+                    backoff = totalCap
+                }
+                continue
+            }
+            s.stream = st
+            utils.Info("Log stream connected")
+        }
+
+        // Brief pause before re-checking for new disconnects
+        time.Sleep(time.Second)
+    }
 }
 
-// SendLogs sends a log payload to the gRPC server.
-// It takes a pointer to a LogPayload object as a parameter.
-// The function converts the log payload to a protobuf format and sends it to the server.
+
+// SendLogs marshals the LogPayload and sends it.
+// If no active stream, returns Unavailable so your worker backoff kicks in.
 func (s *LogSender) SendLogs(payload *model.LogPayload) error {
-	pbLogs := make([]*proto.LogEntry, 0, len(payload.Logs))
-	utils.Debug("Log Meta: %v", payload.Meta)
-	for _, log := range payload.Logs {
-		pbLog := &proto.LogEntry{
-			Timestamp: timestamppb.New(log.Timestamp),
-			Level:     log.Level,
-			Message:   log.Message,
-			Source:    log.Source,
-			Category:  log.Category,
-			Pid:       int32(log.PID),
-			Fields:    log.Fields,
-			Tags:      log.Tags,
-			Meta:      protohelper.ConvertLogMetaToProto(log.Meta),
-		}
-		//utils.Debug("Sender: LogEntry: %v", pbLog)
-		//utils.Debug("Sender:LogMeta: %v", pbLog.Meta)
+    if s.stream == nil {
+        return status.Error(codes.Unavailable, "no active log stream")
+    }
 
-		pbLogs = append(pbLogs, pbLog)
-	}
+    // --- your existing conversion logic :contentReference[oaicite:0]{index=0}:contentReference[oaicite:1]{index=1} ---
+    pbLogs := make([]*proto.LogEntry, 0, len(payload.Logs))
+    for _, log := range payload.Logs {
+        pb := &proto.LogEntry{
+            Timestamp: timestamppb.New(log.Timestamp),
+            Level:     log.Level,
+            Message:   log.Message,
+            Source:    log.Source,
+            Category:  log.Category,
+            Pid:       int32(log.PID),
+            Fields:    log.Fields,
+            Tags:      log.Tags,
+            Meta:      protohelper.ConvertLogMetaToProto(log.Meta),
+        }
+        pbLogs = append(pbLogs, pb)
+    }
+    var metaProto *proto.Meta
+    if payload.Meta != nil {
+        metaProto = protohelper.ConvertMetaToProtoMeta(payload.Meta)
+    }
+    req := &proto.LogPayload{
+        AgentId:    payload.AgentID,
+        HostId:     payload.HostID,
+        Hostname:   payload.Hostname,
+        EndpointId: payload.EndpointID,
+        Timestamp:  timestamppb.New(payload.Timestamp),
+        Logs:       pbLogs,
+        Meta:       metaProto,
+    }
+    // --- end conversion ---
 
-	var convertedMeta *proto.Meta
+    // verify marshal
+    if _, err := goproto.Marshal(req); err != nil {
+        utils.Error("Failed to marshal LogPayload: %v", err)
+        return err
+    }
 
-	// Convert meta to proto
-	if payload.Meta != nil {
-		convertedMeta = protohelper.ConvertMetaToProtoMeta(payload.Meta)
-	}
-
-	req := &proto.LogPayload{
-		AgentId:    payload.AgentID,
-		HostId:     payload.HostID,
-		Hostname:   payload.Hostname,
-		EndpointId: payload.EndpointID,
-		Timestamp:  timestamppb.New(payload.Timestamp),
-		Logs:       pbLogs,
-		Meta:       convertedMeta,
-	}
-	// Marshal manually to check for proto errors
-	_, err := goproto.Marshal(req)
-	if err != nil {
-		utils.Error("Failed to marshal proto.LogPayload: %v", err)
-		return err
-	}
-	//utils.Debug("Marshaled LogPayload size = %d bytes", len(b))
-
-	// Try sending
-	err = s.stream.Send(req)
-	if err != nil {
-		utils.Warn("Log stream send failed: %v", err)
-
-		// Check if it's retryable
-		if stat, ok := status.FromError(err); ok {
-			if stat.Code() == codes.Unavailable || stat.Code() == codes.Canceled || stat.Code() == codes.DeadlineExceeded {
-				utils.Warn("Stream error %v detected, reconnecting...", stat.Code())
-
-				if reconnectErr := s.reconnectStream(context.Background()); reconnectErr != nil {
-					return reconnectErr
-				}
-
-				// After reconnecting, retry sending once
-				utils.Debug("Retrying after reconnect...")
-				return s.stream.Send(req)
-			}
-		}
-
-		// Other types of errors: return immediately
-		return err
-	}
-
-	utils.Debug("Streamed %d logs", len(pbLogs))
-	return nil
+    // send
+    if err := s.stream.Send(req); err != nil {
+        utils.Warn("Log stream send failed: %v", err)
+        return err
+    }
+    utils.Debug("Streamed %d logs", len(pbLogs))
+    return nil
 }
 
-// reconnectStream attempts to reconnect the log stream.
-// It closes the existing stream and opens a new one.
-// The function logs the status of the reconnection attempt and returns an error if it fails.
-// It uses the context passed as a parameter to manage the lifecycle of the stream.
-func (s *LogSender) reconnectStream(ctx context.Context) error {
-	utils.Warn("Attempting to reconnect log stream...")
-
-	// Close existing stream
-	if s.stream != nil {
-		_ = s.stream.CloseSend() // best effort
-	}
-
-	// Open a new stream
-	newStream, err := s.client.SubmitStream(ctx)
-	if err != nil {
-		utils.Error("Failed to reconnect log stream: %v", err)
-		return err
-	}
-
-	s.stream = newStream
-	utils.Info("Reconnected log stream successfully")
-	return nil
+// Close shuts down worker pool and closes the gRPC connection.
+func (s *LogSender) Close() error {
+    utils.Info("Closing LogSender... waiting for workers")
+    s.wg.Wait()
+    utils.Info("All LogSender workers finished")
+    return s.cc.Close()
 }

--- a/internal/logs/logsender/task.go
+++ b/internal/logs/logsender/task.go
@@ -67,7 +67,7 @@ func (s *LogSender) StartWorkerPool(ctx context.Context, queue <-chan *model.Log
 
                 //  Send (errors will be logged)
                 if err := s.SendLogs(payload); err != nil {
-                    utils.Error("Log worker #%d failed to send payload: %v", id, err)
+                    utils.Warn("Log worker #%d failed to send payload: %v", id, err)
                 }
             }
         }(i + 1)

--- a/internal/logs/logsender/task.go
+++ b/internal/logs/logsender/task.go
@@ -37,23 +37,41 @@ import (
 // to the gRPC server. The number of workers is determined by the workerCount
 // parameter. The workers will run until the context is done or an error occurs.
 func (s *LogSender) StartWorkerPool(ctx context.Context, queue <-chan *model.LogPayload, workerCount int) {
-	for i := 0; i < workerCount; i++ {
-		s.wg.Add(1) // track worker
-		go func(id int) {
-			defer s.wg.Done() // signal on exit
-			for {
-				select {
-				case <-ctx.Done():
-					utils.Info("Worker %d shutting down", id)
-					return
-				case payload := <-queue:
-					if err := s.trySendWithBackoff(payload); err != nil {
-						utils.Error("Worker %d failed to send payload: %v", id, err)
-					}
-				}
-			}
-		}(i + 1)
-	}
+    for i := 0; i < workerCount; i++ {
+        s.wg.Add(1)
+        go func(id int) {
+            defer s.wg.Done()
+            for {
+                //  Exit if the runner context is done
+                select {
+                case <-ctx.Done():
+                    utils.Info("Log worker #%d shutting down", id)
+                    return
+                default:
+                }
+
+                //  If not connected, wait and retry
+                if s.stream == nil {
+                    time.Sleep(500 * time.Millisecond)
+                    continue
+                }
+
+                //  Pull next payload (or exit)
+                var payload *model.LogPayload
+                select {
+                case payload = <-queue:
+                case <-ctx.Done():
+                    utils.Info("Log worker #%d shutting down", id)
+                    return
+                }
+
+                //  Send (errors will be logged)
+                if err := s.SendLogs(payload); err != nil {
+                    utils.Error("Log worker #%d failed to send payload: %v", id, err)
+                }
+            }
+        }(i + 1)
+    }
 }
 
 // trySendWithBackoff attempts to send the log payload to the server with exponential backoff.
@@ -65,7 +83,7 @@ func (s *LogSender) trySendWithBackoff(payload *model.LogPayload) error {
 	backoff := 500 * time.Millisecond
 	maxBackoff := 10 * time.Second
 
-	for retries := 0; retries < 5; retries++ {
+	for retries := 0; retries < 1; retries++ {
 		err = s.SendLogs(payload)
 		if err == nil {
 			return nil

--- a/internal/metrics/metricsender/sender.go
+++ b/internal/metrics/metricsender/sender.go
@@ -19,8 +19,6 @@ You should have received a copy of the GNU General Public License
 along with GoSight. If not, see https://www.gnu.org/licenses/.
 */
 
-// gosight/agent/internal/sender/sender.go
-
 package metricsender
 
 import (
@@ -37,243 +35,289 @@ import (
 	"github.com/aaronlmathis/gosight-shared/proto"
 	"github.com/aaronlmathis/gosight-shared/utils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Sender holds the gRPC client and connection
+const (
+    pauseDuration = 1 * time.Minute
+    totalCap      = 15 * time.Minute
+)
+
+// MetricSender handles streaming metrics and control commands.
 type MetricSender struct {
-	client proto.StreamServiceClient
-	cc     *grpc.ClientConn
-	stream proto.StreamService_StreamClient
-	wg     sync.WaitGroup
-	cfg    *config.Config
-	ctx    context.Context
+    client proto.StreamServiceClient
+    cc     *grpc.ClientConn
+    stream proto.StreamService_StreamClient
+    wg     sync.WaitGroup
+    cfg    *config.Config
+    ctx    context.Context
 }
 
-// NewSender establishes a gRPC connection
-// and creates a stream for sending metrics
-// It returns a MetricSender instance
+// NewSender returns immediately and starts a background connection manager.
 func NewSender(ctx context.Context, cfg *config.Config) (*MetricSender, error) {
-
-	clientConn, err := grpcconn.GetGRPCConn(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create gRPC client
-	// and establish a stream for sending metrics
-	client := proto.NewStreamServiceClient(clientConn)
-	utils.Info("established gRPC Connection with %v", cfg.Agent.ServerURL)
-
-	//
-	stream, err := client.Stream(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open stream: %w", err)
-	}
-
-	sender := &MetricSender{
-		ctx:    ctx,
-		client: client,
-		cc:     clientConn,
-		stream: stream,
-		cfg:    cfg,
-	}
-	go sender.receiveResponses()
-
-	return sender, nil
+    s := &MetricSender{
+        ctx: ctx,
+        cfg: cfg,
+    }
+    go s.manageConnection()
+    return s, nil
 }
 
-// Close waits for all workers to finish and closes the gRPC connection
-// It returns an error if the connection could not be closed
-// or if any worker failed
-func (s *MetricSender) Close() error {
-	utils.Info("Closing MetricSender... waiting for workers")
-	s.wg.Wait()
-	utils.Info("All MetricSender workers finished")
-	return s.cc.Close()
+// manageConnection dials/opens the stream with backoff, handles global disconnects.
+func (s *MetricSender) manageConnection() {
+    const (
+        initial    = 1 * time.Second
+        maxBackoff = 10 * time.Second
+        totalCap   = 15 * time.Minute
+    )
+
+    backoff := initial
+    elapsed := time.Duration(0)
+
+    for {
+        // respect any global pause
+        grpcconn.WaitForResume()
+
+        //  on a "disconnect" command: tear down _only_ the stream, reset backoff, loop
+        select {
+        case <-grpcconn.DisconnectNotify():
+            utils.Info("Global disconnect: closing metric stream")
+            if s.stream != nil {
+                _ = s.stream.CloseSend()
+            }
+            s.stream = nil
+            backoff = initial
+            elapsed = 0
+            continue
+        default:
+        }
+
+        // get (or dial) a healthy ClientConn
+        
+        cc, err := grpcconn.GetGRPCConn(s.cfg)
+        if err != nil {
+            utils.Warn("gRPC dial for metrics failed: %v", err)
+            time.Sleep(backoff)
+            elapsed += backoff
+            if backoff < maxBackoff {
+                backoff *= 2
+            }
+            if elapsed >= totalCap {
+                backoff = totalCap
+            }
+            continue
+        }
+        s.cc = cc
+        s.client = proto.NewStreamServiceClient(cc)
+
+        //  open the stream if we don’t have one yet
+        if s.stream == nil {
+            stream, err := s.client.Stream(s.ctx)
+            if err != nil {
+                utils.Warn("Metric Stream open failed: %v", err)
+                time.Sleep(backoff)
+                elapsed += backoff
+                if backoff < maxBackoff {
+                    backoff *= 2
+                }
+                if elapsed >= totalCap {
+                    backoff = totalCap
+                }
+                continue
+            }
+            s.stream = stream
+            utils.Info("Metrics stream connected")
+        }
+
+        // 5) block in your existing receive loop
+        s.manageReceive()
+
+        //  on exit from receive (error or next disconnect), just close the stream
+        if s.stream != nil {
+            _ = s.stream.CloseSend()
+        }
+        s.stream = nil
+
+        //  brief backoff before retrying
+        time.Sleep(backoff)
+        elapsed += backoff
+        if backoff < maxBackoff {
+            backoff *= 2
+        }
+        if elapsed >= totalCap {
+            backoff = totalCap
+        }
+    }
 }
 
-// SendMetrics sends a MetricPayload to the server
-// It converts the MetricPayload to a protobuf message
-// and sends it over the gRPC stream
+// SendMetrics marshals and sends a MetricPayload. If no stream, returns Unavailable.
 func (s *MetricSender) SendMetrics(payload *model.MetricPayload) error {
-	pbMetrics := make([]*proto.Metric, 0, len(payload.Metrics))
-	for _, m := range payload.Metrics {
-		pbMetric := &proto.Metric{
-			Name:         m.Name,
-			Namespace:    m.Namespace,
-			Subnamespace: m.SubNamespace,
-			Timestamp:    timestamppb.New(m.Timestamp),
+    if s.stream == nil {
+        return status.Error(codes.Unavailable, "no active metrics stream")
+    }
 
-			Value:             m.Value,
-			Unit:              m.Unit,
-			StorageResolution: int32(m.StorageResolution),
-			Type:              m.Type,
-			Dimensions:        m.Dimensions,
-		}
-		if m.StatisticValues != nil {
-			pbMetric.StatisticValues = &proto.StatisticValues{
-				Minimum:     m.StatisticValues.Minimum,
-				Maximum:     m.StatisticValues.Maximum,
-				SampleCount: int32(m.StatisticValues.SampleCount),
-				Sum:         m.StatisticValues.Sum,
-			}
-		}
-		pbMetrics = append(pbMetrics, pbMetric)
-	}
-	var convertedMeta *proto.Meta
+    pbMetrics := make([]*proto.Metric, 0, len(payload.Metrics))
+    for _, m := range payload.Metrics {
+        pm := &proto.Metric{
+            Name:         m.Name,
+            Namespace:    m.Namespace,
+            Subnamespace: m.SubNamespace,
+            Timestamp:    timestamppb.New(m.Timestamp),
+            Value:             m.Value,
+            Unit:              m.Unit,
+            StorageResolution: int32(m.StorageResolution),
+            Type:              m.Type,
+            Dimensions:        m.Dimensions,
+        }
+        if sv := m.StatisticValues; sv != nil {
+            pm.StatisticValues = &proto.StatisticValues{
+                Minimum:     sv.Minimum,
+                Maximum:     sv.Maximum,
+                SampleCount: int32(sv.SampleCount),
+                Sum:         sv.Sum,
+            }
+        }
+        pbMetrics = append(pbMetrics, pm)
+    }
 
-	// Convert meta to proto
-	if payload.Meta != nil {
-		convertedMeta = protohelper.ConvertMetaToProtoMeta(payload.Meta)
-	}
-	//utils.Debug("Proto Meta Tags: %+v", convertedMeta)
+    var metaProto *proto.Meta
+    if payload.Meta != nil {
+        metaProto = protohelper.ConvertMetaToProtoMeta(payload.Meta)
+    }
 
-	metricPayload := &proto.MetricPayload{
-		AgentId:    payload.AgentID,
-		HostId:     payload.HostID,
-		Hostname:   payload.Hostname,
-		EndpointId: payload.EndpointID,
-		Timestamp:  timestamppb.New(payload.Timestamp),
-		Metrics:    pbMetrics,
-		Meta:       convertedMeta,
-	}
+    metricPayload := &proto.MetricPayload{
+        AgentId:    payload.AgentID,
+        HostId:     payload.HostID,
+        Hostname:   payload.Hostname,
+        EndpointId: payload.EndpointID,
+        Timestamp:  timestamppb.New(payload.Timestamp),
+        Metrics:    pbMetrics,
+        Meta:       metaProto,
+    }
 
-	b, err := goproto.Marshal(metricPayload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal MetricPayload: %w", err)
-	}
+    b, err := goproto.Marshal(metricPayload)
+    if err != nil {
+        return fmt.Errorf("failed to marshal MetricPayload: %w", err)
+    }
 
-	streamPayload := &proto.StreamPayload{
-		Payload: &proto.StreamPayload_Metric{
-			Metric: &proto.MetricWrapper{
-				RawPayload: b,
-			},
-		},
-	}
-	sendCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+    streamPayload := &proto.StreamPayload{
+        Payload: &proto.StreamPayload_Metric{
+            Metric: &proto.MetricWrapper{RawPayload: b},
+        },
+    }
+    // --- end conversion ---
 
-	sendCh := make(chan error, 1)
-	go func() {
-		sendCh <- s.stream.Send(streamPayload)
-	}()
+    // send with timeout
+    sendCtx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+    defer cancel()
+    errCh := make(chan error, 1)
+    go func() { errCh <- s.stream.Send(streamPayload) }()
 
-	select {
-	case err := <-sendCh:
-		if err != nil {
-			return fmt.Errorf("stream send failed: %w", err)
-		}
-		return nil
-	case <-sendCtx.Done():
-		return fmt.Errorf("stream send timeout")
-	}
+    select {
+    case err := <-errCh:
+        if err != nil {
+            return fmt.Errorf("stream send failed: %w", err)
+        }
+        return nil
+    case <-sendCtx.Done():
+        return fmt.Errorf("stream send timeout")
+    }
 }
 
-// receiveResponses listens for commands sent from server.
-// It handles the commands and sends back responses.
-// It runs in a separate goroutine and handles reconnections
-// in case of errors.
-func (s *MetricSender) receiveResponses() {
-	for {
-		resp, err := s.stream.Recv()
-		if err != nil {
-			select {
-			case <-s.ctx.Done():
-				utils.Info("Context canceled, exiting receive loop cleanly")
-				return
-			default:
-				utils.Error("Stream receive error: %v", err)
+// manageReceive handles incoming commands; on a disconnect command, broadcasts global pause.
+func (s *MetricSender) manageReceive() {
+    for {
+        resp, err := s.stream.Recv()
+        if err != nil {
+            if s.ctx.Err() != nil {
+                utils.Info("Receive loop canceled")
+            } else {
+                utils.Error("Stream receive error: %v", err)
+            }
+            return
+        }
 
-				if recErr := s.reconnectStream(); recErr != nil {
-					utils.Error("Failed to reconnect stream: %v", recErr)
-					return
-				}
-				utils.Info("Successfully reconnected stream after failure")
-				continue
-			}
-		}
+        if cmd := resp.Command; cmd != nil &&
+            cmd.CommandType == "control" &&
+            cmd.Command == "disconnect" {
 
-		utils.Debug("Received StreamResponse: status=%s", resp.Status)
-		utils.Debug("Response Payload: %v", resp)
-		if resp.Command != nil {
-			utils.Info("Received CommandRequest: type=%s command=%s", resp.Command.CommandType, resp.Command.Command)
-			result := command.HandleCommand(s.ctx, resp.Command)
-			if result != nil {
-				s.sendCommandResponseWithRetry(result)
-			}
-		}
-	}
+            utils.Info("Received global disconnect; pausing all senders for %v", pauseDuration)
+            grpcconn.PauseConnections(pauseDuration)
+            return
+        }
+
+        if resp.Command != nil {
+            utils.Info("Handling command %s/%s", resp.Command.CommandType, resp.Command.Command)
+            if result := command.HandleCommand(s.ctx, resp.Command); result != nil {
+                s.sendCommandResponseWithRetry(result)
+            }
+        }
+    }
 }
 
-// reconnectStream attempts to reconnect the gRPC stream.
-// It closes the old connection and creates a new one.
-// It returns an error if the reconnection fails.
+// Close waits for any in-flight work then closes the connection.
+func (s *MetricSender) Close() error {
+    utils.Info("Closing MetricSender... waiting for workers")
+    s.wg.Wait()
+    utils.Info("All workers done")
+    return s.cc.Close()
+}
+
+// reconnectStream re-dials and reopens the stream for sendCommandResponseWithRetry.
 func (s *MetricSender) reconnectStream() error {
-	var err error
-	// Close old connection safely if you want (optional)
-	if s.cc != nil {
-		_ = s.cc.Close()
-	}
+    if s.cc != nil {
+        _ = s.cc.Close()
+    }
+    ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+    defer cancel()
 
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
-	defer cancel()
+    conn, err := grpcconn.GetGRPCConn(s.cfg)
+    if err != nil {
+        return fmt.Errorf("failed to reconnect: %w", err)
+    }
+    s.cc = conn
+    s.client = proto.NewStreamServiceClient(conn)
 
-	// Rebuild gRPC client connection
-	conn, err := grpcconn.GetGRPCConn(s.cfg) // Use your same logic
-	if err != nil {
-		return fmt.Errorf("failed to reconnect gRPC: %w", err)
-	}
-
-	s.cc = conn
-	s.client = proto.NewStreamServiceClient(conn)
-
-	stream, err := s.client.Stream(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to reopen stream: %w", err)
-	}
-
-	s.stream = stream
-	return nil
+    stream, err := s.client.Stream(ctx)
+    if err != nil {
+        return fmt.Errorf("failed to reopen stream: %w", err)
+    }
+    s.stream = stream
+    return nil
 }
 
-// sendCommandResponseWithRetry attempts to send a CommandResponse with retries
-// It uses exponential backoff for retries
-// It sends the CommandResponse over the gRPC stream
-// It handles errors and timeouts
+// sendCommandResponseWithRetry retries CommandResponse up to 3 times with backoff.
 func (s *MetricSender) sendCommandResponseWithRetry(resp *proto.CommandResponse) {
-	const maxAttempts = 3
+    const maxAttempts = 3
+    for attempt := 1; attempt <= maxAttempts; attempt++ {
+        sendCtx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+        defer cancel()
 
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		sendCtx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-		defer cancel()
+        done := make(chan error, 1)
+        go func() {
+            done <- s.stream.Send(&proto.StreamPayload{
+                Payload: &proto.StreamPayload_CommandResponse{CommandResponse: resp},
+            })
+        }()
 
-		done := make(chan error, 1)
-		go func() {
-			done <- s.stream.Send(&proto.StreamPayload{
-				Payload: &proto.StreamPayload_CommandResponse{
-					CommandResponse: resp,
-				},
-			})
-		}()
-
-		select {
-		case err := <-done:
-			if err != nil {
-				utils.Warn("Send attempt %d failed: %v", attempt, err)
-				_ = s.reconnectStream()
-				time.Sleep(time.Duration(attempt) * time.Second)
-				continue
-			}
-			utils.Debug("CommandResponse sent on attempt %d", attempt)
-			return
-		case <-sendCtx.Done():
-			utils.Warn("Send attempt %d timed out", attempt)
-			_ = s.reconnectStream()
-			time.Sleep(time.Duration(attempt) * time.Second)
-		}
-	}
-
-	utils.Error("Failed to send CommandResponse after %d attempts: %v", maxAttempts, resp)
+        select {
+        case err := <-done:
+            if err != nil {
+                utils.Warn("CommandResponse send attempt %d failed: %v", attempt, err)
+                _ = s.reconnectStream()
+                time.Sleep(time.Duration(attempt) * time.Second)
+                continue
+            }
+            utils.Debug("CommandResponse sent on attempt %d", attempt)
+            return
+        case <-sendCtx.Done():
+            utils.Warn("CommandResponse send attempt %d timed out", attempt)
+            _ = s.reconnectStream()
+            time.Sleep(time.Duration(attempt) * time.Second)
+        }
+    }
+    utils.Error("Failed to send CommandResponse after %d attempts", maxAttempts)
 }

--- a/internal/metrics/metricsender/task.go
+++ b/internal/metrics/metricsender/task.go
@@ -71,7 +71,7 @@ func (s *MetricSender) StartWorkerPool(ctx context.Context, queue <-chan *model.
 
                 // 4) Send (errors will be logged)
                 if err := s.SendMetrics(payload); err != nil {
-                    utils.Error("Metric worker #%d failed to send payload: %v", id, err)
+                    utils.Warn("Metric worker #%d failed to send payload: %v", id, err)
                 }
             }
         }(i + 1)

--- a/internal/metrics/metricsender/task.go
+++ b/internal/metrics/metricsender/task.go
@@ -41,25 +41,42 @@ import (
 // parameter. The workers will run until the context is done or an error occurs.
 // The function uses a goroutine for each worker, allowing them to run concurrently.
 func (s *MetricSender) StartWorkerPool(ctx context.Context, queue <-chan *model.MetricPayload, workerCount int) {
-	for i := 0; i < workerCount; i++ {
-		s.wg.Add(1) // track worker
-		go func(id int) {
-			defer s.wg.Done() // signal on exit
-			for {
-				select {
-				case <-ctx.Done():
-					utils.Info("Worker %d shutting down", id)
-					return
-				case payload := <-queue:
-					if err := s.trySendWithBackoff(payload); err != nil {
-						utils.Error("Worker %d failed to send payload: %v", id, err)
-					}
-				}
-			}
-		}(i + 1)
-	}
-}
+    for i := 0; i < workerCount; i++ {
+        s.wg.Add(1)
+        go func(id int) {
+            defer s.wg.Done()
+            for {
+                // Exit if the runner context is done
+                select {
+                case <-ctx.Done():
+                    utils.Info("Metric worker #%d shutting down", id)
+                    return
+                default:
+                }
 
+                // If not connected, wait and retry
+                if s.stream == nil {
+                    time.Sleep(500 * time.Millisecond)
+                    continue
+                }
+
+                // Pull next payload (or exit)
+                var payload *model.MetricPayload
+                select {
+                case payload = <-queue:
+                case <-ctx.Done():
+                    utils.Info("Metric worker #%d shutting down", id)
+                    return
+                }
+
+                // 4) Send (errors will be logged)
+                if err := s.SendMetrics(payload); err != nil {
+                    utils.Error("Metric worker #%d failed to send payload: %v", id, err)
+                }
+            }
+        }(i + 1)
+    }
+}
 // trySendWithBackoff attempts to send the metric payload to the gRPC server.
 // It uses exponential backoff for retries in case of transient errors.
 // The function will retry sending the payload up to 5 times with increasing
@@ -70,7 +87,7 @@ func (s *MetricSender) trySendWithBackoff(payload *model.MetricPayload) error {
 	backoff := 500 * time.Millisecond
 	maxBackoff := 10 * time.Second
 
-	for attempt := 1; attempt <= 5; attempt++ {
+	for attempt := 1; attempt <= 1; attempt++ {
 		err = s.SendMetrics(payload)
 		if err == nil {
 			return nil

--- a/internal/processes/processrunner/processrunner.go
+++ b/internal/processes/processrunner/processrunner.go
@@ -66,7 +66,8 @@ func NewRunner(ctx context.Context, cfg *config.Config, baseMeta *model.Meta) (*
 // This allows the user to define custom behavior when the connection to the server is lost.
 // The handler function will be called when the disconnect event occurs.
 func (r *ProcessRunner) SetDisconnectHandler(fn func()) {
-	r.ProcessSender.SetDisconnectHandler(fn)
+	//r.ProcessSender.SetDisconnectHandler(fn)
+	return
 }
 
 // Close closes the process sender and cleans up resources.

--- a/internal/processes/processsender/processsender.go
+++ b/internal/processes/processsender/processsender.go
@@ -20,9 +20,7 @@ along with GoSight. If not, see https://www.gnu.org/licenses/.
 */
 
 // agent/processes/processsender/sender.go
-// Package processsender provides functionality to send process data to a gRPC server.
-// It handles the connection to the server, sending process snapshots, and
-// reconnecting the stream in case of disconnection.
+
 package processsender
 
 import (
@@ -37,219 +35,159 @@ import (
 	"github.com/aaronlmathis/gosight-shared/model"
 	"github.com/aaronlmathis/gosight-shared/proto"
 	"github.com/aaronlmathis/gosight-shared/utils"
-	goproto "google.golang.org/protobuf/proto"
-
 	"google.golang.org/grpc"
-
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// ProcessSender is a struct that handles sending process data to a gRPC server.
-// It manages the connection to the server, sending process snapshots, and
-// reconnecting the stream in case of disconnection.
-// It implements the Close method to clean up resources and the SendSnapshot method
-// to send process data.
+const (
+    pauseDuration = 1 * time.Minute
+    totalCap      = 15 * time.Minute
+)
+
+// ProcessSender handles streaming process snapshots and reacts to global disconnects.
 type ProcessSender struct {
-	cfg          *config.Config
-	ctx          context.Context
-	cc           *grpc.ClientConn
-	client       proto.StreamServiceClient
-	stream       proto.StreamService_StreamClient
-	wg           sync.WaitGroup
-	streamCtx    context.Context
-	streamCancel context.CancelFunc
-	onDisconnect func()
+    cfg    *config.Config
+    ctx    context.Context
+    cc     *grpc.ClientConn
+    client proto.StreamServiceClient
+    stream proto.StreamService_StreamClient
+    wg     sync.WaitGroup
 }
 
-// NewSender creates a new ProcessSender instance.
-// It initializes the gRPC connection and stream to the server.
-// It returns a pointer to the ProcessSender and an error if any occurs during initialization.
-// The context is used to manage the lifecycle of the sender.
+// NewSender returns immediately and starts manageConnection in background.
 func NewSender(ctx context.Context, cfg *config.Config) (*ProcessSender, error) {
-	cc, err := grpcconn.GetGRPCConn(cfg)
-	if err != nil {
-		return nil, err
-	}
-	client := proto.NewStreamServiceClient(cc)
-	streamCtx, cancel := context.WithCancel(ctx)
-	stream, err := client.Stream(streamCtx)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	return &ProcessSender{
-		cfg:          cfg,
-		ctx:          ctx,
-		cc:           cc,
-		client:       client,
-		stream:       stream,
-		streamCtx:    streamCtx,
-		streamCancel: cancel,
-	}, nil
+    s := &ProcessSender{ctx: ctx, cfg: cfg}
+    go s.manageConnection()
+    return s, nil
 }
 
-// SetDisconnectHandler sets a callback function to be called when the sender disconnects.
-// This is useful for handling reconnections or cleanup tasks when the sender is no longer able to send data.
-func (s *ProcessSender) SetDisconnectHandler(fn func()) {
-	s.onDisconnect = fn
+// manageConnection dials + opens the Stream, tears down on global disconnect,
+// and retries with exponential backoff up to totalCap.
+func (s *ProcessSender) manageConnection() {
+    const (
+        initial    = 1 * time.Second
+        maxBackoff = 10 * time.Second
+        totalCap   = 15 * time.Minute
+    )
+
+    backoff := initial
+    elapsed := time.Duration(0)
+    var lastPause time.Time
+
+    for {
+        // 1) If pauseUntil has advanced since we last saw it, tear down our stream
+        pu := grpcconn.GetPauseUntil()
+        if pu.After(lastPause) {
+            utils.Info("Global disconnect: closing process stream")
+            if s.stream != nil {
+                _ = s.stream.CloseSend()
+            }
+            s.stream = nil
+            backoff = initial
+            elapsed = 0
+            lastPause = pu
+        }
+
+        // 2) Wait out the pause window (if any)
+        grpcconn.WaitForResume()
+
+        // 3) (Re)dial a healthy ClientConn
+        cc, err := grpcconn.GetGRPCConn(s.cfg)
+        if err != nil {
+            utils.Warn("gRPC dial failed for processes: %v", err)
+            time.Sleep(backoff)
+            elapsed += backoff
+            if backoff < maxBackoff {
+                backoff *= 2
+            }
+            if elapsed >= totalCap {
+                backoff = totalCap
+            }
+            continue
+        }
+        s.cc = cc
+        s.client = proto.NewStreamServiceClient(cc)
+        backoff = initial
+        elapsed = 0
+
+        // 4) Open the process stream if we don’t already have one
+        if s.stream == nil {
+            st, err := s.client.Stream(s.ctx)
+            if err != nil {
+                utils.Warn("Process stream open failed: %v", err)
+                time.Sleep(backoff)
+                elapsed += backoff
+                if backoff < maxBackoff {
+                    backoff *= 2
+                }
+                if elapsed >= totalCap {
+                    backoff = totalCap
+                }
+                continue
+            }
+            s.stream = st
+            utils.Info("Process stream connected")
+        }
+
+        // 5) Short sleep before looping to pick up future disconnects
+        time.Sleep(time.Second)
+    }
 }
-
-// Close closes the gRPC connection and waits for all background workers to finish.
-// It cancels the stream context to stop any active Send operations.
-// It returns an error if any occurs during the closing process.
-func (s *ProcessSender) Close() error {
-	utils.Info("Closing ProcessSender...")
-
-	// Cancel stream context to stop any active Send operations
-	if s.streamCancel != nil {
-		s.streamCancel()
-	}
-
-	// Wait for background workers to finish
-	s.wg.Wait()
-	utils.Info("All ProcessSender workers finished")
-
-	// Close gRPC connection
-	if s.cc != nil {
-		if err := s.cc.Close(); err != nil {
-			utils.Warn("Error closing gRPC connection: %v", err)
-			return err
-		}
-	}
-
-	utils.Info("ProcessSender closed successfully")
-	return nil
-}
-
-// SendSnapshot sends a snapshot of process data to the gRPC server.
-// It marshals the process data into a protobuf message and sends it over the stream.
-// It handles reconnections in case of disconnection or errors during sending.
-// It returns an error if any occurs during the sending process.
+// SendSnapshot sends a ProcessPayload; if stream is down, returns Unavailable.
 func (s *ProcessSender) SendSnapshot(payload *model.ProcessPayload) error {
-	pb := &proto.ProcessPayload{
-		AgentId:    payload.AgentID,
-		HostId:     payload.HostID,
-		Hostname:   payload.Hostname,
-		EndpointId: payload.EndpointID,
-		Timestamp:  timestamppb.New(payload.Timestamp),
-		Meta:       protohelper.ConvertMetaToProtoMeta(payload.Meta),
-	}
+    if s.stream == nil {
+        return status.Error(codes.Unavailable, "no active process stream")
+    }
 
-	for _, p := range payload.Processes {
-		pb.Processes = append(pb.Processes, &proto.ProcessInfo{
-			Pid:        int32(p.PID),
-			Ppid:       int32(p.PPID),
-			User:       p.User,
-			Executable: p.Executable,
-			Cmdline:    p.Cmdline,
-			CpuPercent: p.CPUPercent,
-			MemPercent: p.MemPercent,
-			Threads:    int32(p.Threads),
-			StartTime:  timestamppb.New(p.StartTime),
-			Tags:       p.Tags,
-		})
-	}
+    // marshal process payload into protobuf
+    pb := &proto.ProcessPayload{
+        AgentId:    payload.AgentID,
+        HostId:     payload.HostID,
+        Hostname:   payload.Hostname,
+        EndpointId: payload.EndpointID,
+        Timestamp:  timestamppb.New(payload.Timestamp),
+        Meta:       protohelper.ConvertMetaToProtoMeta(payload.Meta),
+    }
+    for _, p := range payload.Processes {
+        pb.Processes = append(pb.Processes, &proto.ProcessInfo{
+            Pid:        int32(p.PID),
+            Ppid:       int32(p.PPID),
+            User:       p.User,
+            Executable: p.Executable,
+            Cmdline:    p.Cmdline,
+            CpuPercent: p.CPUPercent,
+            MemPercent: p.MemPercent,
+            Threads:    int32(p.Threads),
+            StartTime:  timestamppb.New(p.StartTime),
+            Tags:       p.Tags,
+        })
+    }
+    b, err := goproto.Marshal(pb)
+    if err != nil {
+        return fmt.Errorf("marshal ProcessPayload: %w", err)
+    }
 
-	b, err := goproto.Marshal(pb)
-	if err != nil {
-		return fmt.Errorf("marshal ProcessPayload: %w", err)
-	}
-
-	sp := &proto.StreamPayload{
-		Payload: &proto.StreamPayload_Process{
-			Process: &proto.ProcessWrapper{
-				RawPayload: b,
-			},
-		},
-	}
-
-	const maxAttempts = 5
-	var backoff = []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second}
-
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		if s.streamCtx.Err() != nil {
-			utils.Warn("ProcessSender context canceled, aborting SendSnapshot")
-			if s.onDisconnect != nil {
-				go s.onDisconnect()
-			}
-			return fmt.Errorf("stream context canceled")
-		}
-		sendCtx, cancel := context.WithTimeout(s.streamCtx, 5*time.Second)
-		sendCh := make(chan error, 1)
-		go func() {
-			sendCh <- s.stream.Send(sp)
-		}()
-
-		select {
-		case err := <-sendCh:
-			cancel()
-			if err != nil {
-				utils.Warn("Unknown process send error — retrying in %v [attempt %d/%d]: %v", backoff[attempt-1], attempt, maxAttempts, err)
-				if recErr := s.reconnectStream(); recErr != nil {
-					utils.Error("Failed to reconnect process stream: %v", recErr)
-					return fmt.Errorf("send failed and reconnect failed: %w", err)
-				}
-				time.Sleep(backoff[attempt-1])
-				continue
-			}
-			return nil
-		case <-sendCtx.Done():
-			cancel()
-			utils.Warn("Process send timed out — retrying in %v [attempt %d/%d]", backoff[attempt-1], attempt, maxAttempts)
-			if recErr := s.reconnectStream(); recErr != nil {
-				utils.Error("Failed to reconnect process stream: %v", recErr)
-				return fmt.Errorf("send timeout and reconnect failed")
-			}
-			time.Sleep(backoff[attempt-1])
-		}
-	}
-
-	utils.Error("All process send attempts failed, triggering onDisconnect")
-	if s.onDisconnect != nil {
-		go s.onDisconnect()
-	}
-
-	return fmt.Errorf("send failed after %d attempts: EOF", maxAttempts)
+    sp := &proto.StreamPayload{
+        Payload: &proto.StreamPayload_Process{
+            Process: &proto.ProcessWrapper{RawPayload: b},
+        },
+    }
+    // send without additional retries
+    if err := s.stream.Send(sp); err != nil {
+        return fmt.Errorf("stream send failed: %w", err)
+    }
+    return nil
 }
 
-// reconnectStream attempts to reconnect the gRPC stream to the server.
-// It closes the old connection and stream context, creates a new connection,
-// and initializes a new stream.
-func (s *ProcessSender) reconnectStream() error {
-	utils.Warn("Attempting to reconnect process stream...")
-
-	// Close old connection and cancel old stream context
-	if s.streamCancel != nil {
-		s.streamCancel()
-	}
-	if s.cc != nil {
-		_ = s.cc.Close()
-	}
-
-	_, cancel := context.WithTimeout(s.ctx, 10*time.Second)
-	defer cancel()
-
-	cc, err := grpcconn.GetGRPCConn(s.cfg)
-	if err != nil {
-		return err
-	}
-
-	client := proto.NewStreamServiceClient(cc)
-	streamCtx, streamCancel := context.WithCancel(s.ctx)
-	stream, err := client.Stream(streamCtx)
-	if err != nil {
-		streamCancel() // avoid leaking context
-		return err
-	}
-
-	// Replace old references
-	s.cc = cc
-	s.client = client
-	s.stream = stream
-	s.streamCtx = streamCtx
-	s.streamCancel = streamCancel
-
-	utils.Info("Reconnected process stream successfully")
-	return nil
+// Close waits for workers then closes the gRPC connection.
+func (s *ProcessSender) Close() error {
+    utils.Info("Closing ProcessSender...")
+    s.wg.Wait()
+    if s.cc != nil {
+        return s.cc.Close()
+    }
+    return nil
 }

--- a/internal/processes/processsender/task.go
+++ b/internal/processes/processsender/task.go
@@ -1,26 +1,3 @@
-/*
-SPDX-License-Identifier: GPL-3.0-or-later
-
-Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
-
-This file is part of GoSight.
-
-GoSight is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-GoSight is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with GoSight. If not, see https://www.gnu.org/licenses/.
-*/
-// Package model contains the data structures used in GoSight.
-// agent/processes/processsender/task.go
-
 package processsender
 
 import (
@@ -36,62 +13,79 @@ import (
 
 // StartWorkerPool starts a pool of workers to process incoming process payloads.
 // Each worker will attempt to send the payload to the gRPC server.
-// The number of workers is determined by the workerCount parameter.
-// The workers will run until the context is done or an error occurs.
-// The function uses a goroutine for each worker, allowing them to run concurrently.
-func (s *ProcessSender) StartWorkerPool(_ context.Context, queue <-chan *model.ProcessPayload, workerCount int) {
-	for i := 0; i < workerCount; i++ {
-		s.wg.Add(1)
-		go func(id int) {
-			defer s.wg.Done()
-			for {
-				select {
-				case <-s.streamCtx.Done():
-					utils.Info("Process worker %d shutting down", id)
-					return
-				case payload := <-queue:
-					if err := s.trySendWithBackoff(payload); err != nil {
-						utils.Error("Process worker %d failed to send payload: %v", id, err)
-					}
-				}
-			}
-		}(i + 1)
-	}
-}
+// The number of workers is determined by workerCount.
+// Workers exit when the sender’s context is done or the queue is closed.
+func (s *ProcessSender) StartWorkerPool(ctx context.Context, queue <-chan *model.ProcessPayload, workerCount int) {
+    for i := 0; i < workerCount; i++ {
+      s.wg.Add(1)
+      go func(id int) {
+        defer s.wg.Done()
+        for {
+          // 1) Exit on shutdown
+          select {
+          case <-ctx.Done():
+            utils.Info("Process worker %d shutting down", id)
+            return
+          default:
+          }
+  
+          // If we’re not yet connected, back off and loop
+          if s.stream == nil {
+            time.Sleep(500 * time.Millisecond)
+            continue
+          }
+  
+          // We have a stream—grab the next payload
+          var payload *model.ProcessPayload
+          select {
+          case payload = <-queue:
+          case <-ctx.Done():
+            utils.Info("Process worker %d shutting down", id)
+            return
+          }
+  
+          // Try to send it
+          if err := s.SendSnapshot(payload); err != nil {
+            utils.Error("Process worker %d failed to send payload: %v", id, err)
+          }
+        }
+      }(i + 1)
+    }
+  }
 
-// trySendWithBackoff attempts to send the process payload to the gRPC server.
-// It uses exponential backoff for retries in case of transient errors.
-// The function will retry sending the payload up to 5 times with increasing backoff times.
-// If the send fails after 5 attempts, it returns an error.
+// trySendWithBackoff attempts to send the process payload using exponential backoff.
+// It retries on Unavailable, DeadlineExceeded, or ResourceExhausted errors.
+// After 5 attempts, returns the last error.
 func (s *ProcessSender) trySendWithBackoff(payload *model.ProcessPayload) error {
-	var err error
-	backoff := 500 * time.Millisecond
-	maxBackoff := 10 * time.Second
+    var err error
+    backoff := 500 * time.Millisecond
+    maxBackoff := 10 * time.Second
 
-	for attempt := 1; attempt <= 5; attempt++ {
-		err = s.SendSnapshot(payload)
-		if err == nil {
-			return nil
-		}
+    for attempt := 1; attempt <= 1; attempt++ {
+        err = s.SendSnapshot(payload)
+        if err == nil {
+            return nil
+        }
 
-		st, ok := status.FromError(err)
-		if ok {
-			switch st.Code() {
-			case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
-				utils.Warn("Transient process send error (%s) — retrying in %v [attempt %d/5]", st.Code(), backoff, attempt)
-			default:
-				utils.Error("Permanent process send error (%s): %v", st.Code(), err)
-				return err
-			}
-		} else {
-			utils.Warn("Unknown process send error — retrying in %v [attempt %d/5]: %v", backoff, attempt, err)
-		}
+        st, ok := status.FromError(err)
+        if ok {
+            switch st.Code() {
+            case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+                utils.Warn("Transient process send error (%s) — retrying in %v [attempt %d/5]", st.Code(), backoff, attempt)
+            default:
+                utils.Error("Permanent process send error (%s): %v", st.Code(), err)
+                return err
+            }
+        } else {
+            utils.Warn("Unknown process send error — retrying in %v [attempt %d/5]: %v", backoff, attempt, err)
+        }
 
-		time.Sleep(backoff)
-		backoff *= 2
-		if backoff > maxBackoff {
-			backoff = maxBackoff
-		}
-	}
-	return fmt.Errorf("process send failed after 5 attempts: %w", err)
+        time.Sleep(backoff)
+        backoff *= 2
+        if backoff > maxBackoff {
+            backoff = maxBackoff
+        }
+    }
+
+    return fmt.Errorf("process send failed after 5 attempts: %w", err)
 }

--- a/internal/processes/processsender/task.go
+++ b/internal/processes/processsender/task.go
@@ -46,7 +46,7 @@ func (s *ProcessSender) StartWorkerPool(ctx context.Context, queue <-chan *model
   
           // Try to send it
           if err := s.SendSnapshot(payload); err != nil {
-            utils.Error("Process worker %d failed to send payload: %v", id, err)
+            utils.Warn("Process worker %d failed to send payload: %v", id, err)
           }
         }
       }(i + 1)


### PR DESCRIPTION
Refactored agent connection handling. Agent does not exit upon inability to connect to server, but enters retry loop with exponential backoff. Agents now disconnect cleanly when server sends disconnect command, allowing server to exit gracefully. Agents wait till server is back up to reconnect.